### PR TITLE
Fix JUMP/JUMPI

### DIFF
--- a/index.js
+++ b/index.js
@@ -175,7 +175,7 @@ function buildJumpMap (segments) {
   let brTable = '(block $0 (br_table'
 
   segments.forEach((seg, index) => {
-    brTable += ' $' + index
+    brTable += ' $' + (index + 1)
     wasm = `(if (i32.eq (get_local $jump_dest) (i32.const ${seg[1]}))
                 (then (i32.const ${index}))
                 (else ${wasm}))`

--- a/index.js
+++ b/index.js
@@ -63,17 +63,23 @@ exports.compileEVM = function (evmCode, stackTrace) {
     let bytes
     switch (op.name) {
       case 'JUMP':
-        wasmCode = `(set_local $sp ${wasmCode})
+        wasmCode = `(block
+                    (set_local $sp ${wasmCode})
                     (set_local $sp (i32.sub (get_local $sp) (i32.const 32)))
                     (set_local $jump_dest (i32.load (i32.add (get_local $sp) (i32.const 32))))
-                    (br $loop)`
+                    (br $loop)
+                    (return (get_local $sp))
+                    )`
         break
       case 'JUMPI':
         // FIXME: br_if should check load the whole item from stack (256bit) and see if it is non-null and return as i32
-        wasmCode = `(set_local $sp ${wasmCode})
+        wasmCode = `(block
+                    (set_local $sp ${wasmCode})
                     (set_local $sp (i32.sub (get_local $sp) (i32.const 32)))
                     (set_local $jump_dest (i32.load (i32.add (get_local $sp) (i32.const 32))))
-                    (br_if $loop (i32.load (get_local $sp)))`
+                    (br_if $loop (i32.load (get_local $sp)))
+                    (return (get_local $sp))
+                    )`
         break
       case 'JUMPDEST':
         addSegement()


### PR DESCRIPTION
This is needed because the inner block in the case of JUMP/JUMPI is not a single instruction.

Unfortunately this code only works with the 0xb or 0xc binary format.