### PR TITLE
Increase scratch space to 248 bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The eWASM contract memory layout is currently as follows:
 | Previous memory cost in word count (4 bytes)
 | (The cost charged for the last memory allocation)
 +---------------------------------------------------
-| Scratch space (32 bytes)
+| Scratch/reserved space (248 bytes)
 +---------------------------------------------------
 | Reserved space for the SHA3 context (1024 bytes)
 +---------------------------------------------------

--- a/tests/opcodeRunner.js
+++ b/tests/opcodeRunner.js
@@ -9,7 +9,7 @@ const argv = require('minimist')(process.argv.slice(2))
 const dir = `${__dirname}/opcode`
 
 // Transcompiled contracts have their EVM1 memory start at this WASM memory location
-const EVM_MEMORY_OFFSET = 33832
+const EVM_MEMORY_OFFSET = 34048
 
 let testFiles = fs.readdirSync(dir).filter((name) => name.endsWith('.json'))
 

--- a/wasm/MLOAD.wast
+++ b/wasm/MLOAD.wast
@@ -10,7 +10,7 @@
   (local $offset2 i64)
   (local $offset3 i64)
 
-  (set_local $memstart (i32.const 33832))
+  (set_local $memstart (i32.const 34048))
 
   ;; load args from the stack
   (set_local $offset0 (i64.load (i32.add (get_local $sp) (i32.const 24))))

--- a/wasm/MSTORE.wast
+++ b/wasm/MSTORE.wast
@@ -16,7 +16,7 @@
   (local $offset2 i64)
   (local $offset3 i64)
 
-  (set_local $memstart (i32.const 33832))
+  (set_local $memstart (i32.const 34048))
 
   ;; load args from the stack
   (set_local $offset0 (i64.load (i32.add (get_local $sp) (i32.const 24))))

--- a/wasm/MSTORE8.wast
+++ b/wasm/MSTORE8.wast
@@ -17,7 +17,7 @@
   (local $offset2 i64)
   (local $offset3 i64)
 
-  (set_local $memstart (i32.const 33832))
+  (set_local $memstart (i32.const 34048))
 
   ;; load args from the stack
   (set_local $offset0 (i64.load (i32.add (get_local $sp) (i32.const 24))))

--- a/wasm/RETURN.wast
+++ b/wasm/RETURN.wast
@@ -15,7 +15,7 @@
   (local $length2 i64)
   (local $length3 i64)
 
-  (set_local $memstart (i32.const 33832))
+  (set_local $memstart (i32.const 34048))
 
   ;; load args from the stack
   (set_local $offset0 (i64.load (i32.add (get_local $sp) (i32.const 24))))


### PR DESCRIPTION
So the reason for this is that we don't need to move around the offsets for MEM*. When we're done we can shrink the scratch space.