### PR TITLE
Link against pthread for binaryen

### DIFF
--- a/libs/evm2wasm/evm2wast.c
+++ b/libs/evm2wasm/evm2wast.c
@@ -245,12 +245,12 @@ static char *padleft(char *bytes, int curr_len, int len)
 	return ret;
 }
 
-/*static char *slice(char *bytes, int len)
+static char *slice(char *bytes, int len)
 {
 	char *ret = malloc(sizeof(len));
 	ret = memcpy(ret, bytes, len);
 	return ret;
-}*/
+}
 
 static int index_of(char **table, char *elem, int len)
 {

--- a/tools/evm2wasm/CMakeLists.txt
+++ b/tools/evm2wasm/CMakeLists.txt
@@ -1,2 +1,5 @@
 add_executable(evm2wasm main.cpp)
-target_link_libraries(evm2wasm PRIVATE libevm2wasm)
+
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+target_link_libraries(evm2wasm PRIVATE libevm2wasm Threads::Threads)


### PR DESCRIPTION
Tried to build evm2wasm#crewrite.  Got the following: 
```
../../deps/src/binaryen-build/lib/libsupport.a(threads.cpp.o): In function `wasm::Thread::Thread()':
threads.cpp:(.text+0xa6d): undefined reference to `pthread_create'
../../libs/evm2wasm/libevm2wasm.a(evm2wast.c.o): In function `evm2wast':
evm2wast.c:(.text+0x14f1): undefined reference to `slice'
collect2: error: ld returned 1 exit status
tools/evm2wasm/CMakeFiles/evm2wasm.dir/build.make:103: recipe for target 'tools/evm2wasm/evm2wasm' failed
make[2]: *** [tools/evm2wasm/evm2wasm] Error 1
CMakeFiles/Makefile2:248: recipe for target 'tools/evm2wasm/CMakeFiles/evm2wasm.dir/all' failed
make[1]: *** [tools/evm2wasm/CMakeFiles/evm2wasm.dir/all] Error 2
Makefile:83: recipe for target 'all' failed
make: *** [all] Error 2
```

The fixes (uncommenting the `slice` function and adding pthreads to the `evm2wasm build) are in this PR.