### PR TITLE
call the correct function when an error occurs

### DIFF
--- a/bin/evm2wasm.js
+++ b/bin/evm2wasm.js
@@ -13,5 +13,5 @@ evm2wasm.evm2wasm(input, {
 }).then(function (output) {
   console.log(output.toString('binary'))
 }).catch(function (err) {
-  console.err('Failed: ' + err)
+  console.error('Failed: ' + err)
 })


### PR DESCRIPTION
Quick fix to change `console.err` to `console.error` when an error is encountered