### PR TITLE
add new CLI options for specifying EVM input, wasm output as files

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,19 @@
 EVM (Ethereum VM 1.0) to [eWASM](https://github.com/ewasm/design) transcompiler. Here is a online [frontend](https://ewasm.github.io/evm2wasm-frontend/dist/).
 
 # INSTALL
-`npm install evm2wasm`
+Clone the repository and run `npm install`
 
 # USE
 There is a commandline tool to transcompile EVM input:
+
+#### Transcompile EVM to WASM
 ```
-$ evm2wasm 0x600160020200 trace
+$ bin/evm2wasm.js -e `evm_bytecode_file` -o `wasm_output_file`
+```
+
+#### Transcompile EVM to WAST
+```
+$ bin/evm2wasm.js -e `evm_bytecode_file` -o `wasm_output_file` --wast
 ```
 
 # DEVELOP

--- a/bin/evm2wasm.js
+++ b/bin/evm2wasm.js
@@ -2,16 +2,98 @@
 
 const evm2wasm = require('../index.js')
 const ethUtil = require('ethereumjs-util')
+const argv = require('minimist')(process.argv.slice(2))
+const fs = require('fs')
 
-const input = ethUtil.toBuffer(process.argv[2])
+//read EVM bytecode from a file
+function readEVM (file) {
+  return new Promise((resolve, reject) => {
+    if (file) {
+      fs.readFile(file, (err, data) => {
+        if (err) {
+          reject(err)
+        }
 
-evm2wasm.evm2wasm(input, {
-  stackTrace: process.argv[3] === 'trace',
-  tempName: 'temp',
-  inlineOps: true,
-  wabt: true
-}).then(function (output) {
-  console.log(output.toString('binary'))
-}).catch(function (err) {
-  console.error('Failed: ' + err)
-})
+        resolve(data) // strip newline
+      })
+    } else {
+      reject("no file")
+    }
+  })
+}
+
+//convert evm bytecode to WASM or WAST
+function convert (bytecode, wast) {
+  return new Promise((resolve, reject) => {
+    outputFile = argv.o ? argv.o : undefined
+
+    if(!bytecode) {
+      resolve(Buffer.from(''))
+    }
+
+    if (wast) {
+      let output = evm2wasm.evm2wast(bytecode, {
+        stackTrace: false,
+        tempName: 'temp',
+        inlineOps: true,
+        wabt: false 
+      })
+      resolve(output)
+    } else {
+      evm2wasm.evm2wasm(bytecode, {
+        stackTrace: false, 
+        tempName: 'temp',
+        inlineOps: true,
+        wabt: false
+      }).then(function (output) {
+        resolve(output)
+      }).catch(function (err) {
+        reject(err)
+      })
+    }
+  })
+}
+
+function storeOrPrintResult(output, outputFile) {
+  return new Promise((resolve, reject) => {
+    if (typeof(output) !== 'string') {
+      output = output.buffer
+    }
+    if (outputFile) {
+      fs.writeFile(outputFile, output, (err) => {
+        if (err) {
+          reject(err)
+        }
+      })
+    } else {
+      console.log(output)
+      resolve()
+    }
+  })
+}
+
+(async () => {
+  let outputFile = argv.o ? argv.o : undefined
+  let wast = argv.wast !== undefined
+  let file = argv.e ? argv.e : undefined
+
+  let bytecode
+
+  try {
+    if (!file) {
+      if (argv._.length > 0) {
+        bytecode = argv._[0]  
+      } else {
+        throw("must provide evm bytecode file or supply bytecode as a non-named argument")
+      }
+    } else {
+      bytecode = await readEVM(file)
+    }
+
+    debugger
+    let result = await convert(bytecode, wast)
+    await storeOrPrintResult(result, outputFile)
+  } catch (err) {
+    console.error("Error: " + err)
+  }
+}) ()

--- a/bin/evm2wasm.js
+++ b/bin/evm2wasm.js
@@ -1,16 +1,15 @@
 #!/usr/bin/env node
 
 const evm2wasm = require('../index.js')
-const ethUtil = require('ethereumjs-util')
 const argv = require('minimist')(process.argv.slice(2))
 const fs = require('fs')
 
-//convert evm bytecode to WASM or WAST
+// convert evm bytecode to WASM or WAST
 function convert (bytecode, wast) {
   return new Promise((resolve, reject) => {
     outputFile = argv.o ? argv.o : undefined
 
-    if(!bytecode) {
+    if (!bytecode) {
       resolve(Buffer.from(''))
     }
 
@@ -19,12 +18,12 @@ function convert (bytecode, wast) {
         stackTrace: false,
         tempName: 'temp',
         inlineOps: true,
-        wabt: false 
+        wabt: false
       })
       resolve(output)
     } else {
       evm2wasm.evm2wasm(bytecode, {
-        stackTrace: false, 
+        stackTrace: false,
         tempName: 'temp',
         inlineOps: true,
         wabt: false
@@ -37,8 +36,8 @@ function convert (bytecode, wast) {
   })
 }
 
-function storeOrPrintResult(output, outputFile) {
-  if (typeof(output) !== 'string') {
+function storeOrPrintResult (output, outputFile) {
+  if (typeof output !== 'string') {
     output = output.buffer
   }
 
@@ -49,7 +48,6 @@ function storeOrPrintResult(output, outputFile) {
   }
 }
 
-
 let outputFile = argv.o ? argv.o : undefined
 let wast = argv.wast !== undefined
 let file = argv.e ? argv.e : undefined
@@ -59,9 +57,9 @@ let bytecode
 try {
   if (!file) {
     if (argv._.length > 0) {
-      bytecode = argv._[0]  
+      bytecode = argv._[0]
     } else {
-      throw("must provide evm bytecode file or supply bytecode as a non-named argument")
+      throw new Error('must provide evm bytecode file or supply bytecode as a non-named argument')
     }
   } else {
     bytecode = fs.readFileSync(file)
@@ -70,8 +68,8 @@ try {
   convert(bytecode, wast).then((result) => {
     storeOrPrintResult(result, outputFile)
   }).catch((err) => {
-    throw(err)
+    throw err
   })
 } catch (err) {
-  console.error("Error: " + err)
+  console.error('Error: ' + err)
 }

--- a/bin/evm2wasm.js
+++ b/bin/evm2wasm.js
@@ -5,23 +5,6 @@ const ethUtil = require('ethereumjs-util')
 const argv = require('minimist')(process.argv.slice(2))
 const fs = require('fs')
 
-//read EVM bytecode from a file
-function readEVM (file) {
-  return new Promise((resolve, reject) => {
-    if (file) {
-      fs.readFile(file, (err, data) => {
-        if (err) {
-          reject(err)
-        }
-
-        resolve(data) // strip newline
-      })
-    } else {
-      reject("no file")
-    }
-  })
-}
-
 //convert evm bytecode to WASM or WAST
 function convert (bytecode, wast) {
   return new Promise((resolve, reject) => {
@@ -55,44 +38,40 @@ function convert (bytecode, wast) {
 }
 
 function storeOrPrintResult(output, outputFile) {
-  return new Promise((resolve, reject) => {
-    if (typeof(output) !== 'string') {
-      output = output.buffer
-    }
-    if (outputFile) {
-      fs.writeFile(outputFile, output, (err) => {
-        if (err) {
-          reject(err)
-        }
-      })
-    } else {
-      console.log(output)
-      resolve()
-    }
-  })
+  if (typeof(output) !== 'string') {
+    output = output.buffer
+  }
+
+  if (outputFile) {
+    fs.writeFileSync(outputFile, output)
+  } else {
+    console.log(Buffer.from(output).toString('binary'))
+  }
 }
 
-(async () => {
-  let outputFile = argv.o ? argv.o : undefined
-  let wast = argv.wast !== undefined
-  let file = argv.e ? argv.e : undefined
 
-  let bytecode
+let outputFile = argv.o ? argv.o : undefined
+let wast = argv.wast !== undefined
+let file = argv.e ? argv.e : undefined
 
-  try {
-    if (!file) {
-      if (argv._.length > 0) {
-        bytecode = argv._[0]  
-      } else {
-        throw("must provide evm bytecode file or supply bytecode as a non-named argument")
-      }
+let bytecode
+
+try {
+  if (!file) {
+    if (argv._.length > 0) {
+      bytecode = argv._[0]  
     } else {
-      bytecode = await readEVM(file)
+      throw("must provide evm bytecode file or supply bytecode as a non-named argument")
     }
-
-    let result = await convert(bytecode, wast)
-    await storeOrPrintResult(result, outputFile)
-  } catch (err) {
-    console.error("Error: " + err)
+  } else {
+    bytecode = fs.readFileSync(file)
   }
-}) ()
+
+  convert(bytecode, wast).then((result) => {
+    storeOrPrintResult(result, outputFile)
+  }).catch((err) => {
+    throw(err)
+  })
+} catch (err) {
+  console.error("Error: " + err)
+}

--- a/bin/evm2wasm.js
+++ b/bin/evm2wasm.js
@@ -90,7 +90,6 @@ function storeOrPrintResult(output, outputFile) {
       bytecode = await readEVM(file)
     }
 
-    debugger
     let result = await convert(bytecode, wast)
     await storeOrPrintResult(result, outputFile)
   } catch (err) {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "loglevel": "1.5.0",
     "merkle-trie": "0.0.0",
     "readable-stream": "2.3.3",
-    "wast2wasm": "0.0.1"
+    "wast2wasm": "git+https://github.com/ewasm/wast2wasm.git#66ced0c04f1bc7d1ebd63c3348c29e26a336bc95"
   },
   "standard": {
     "ignore": [


### PR DESCRIPTION
Adds two commandline arguments:
  * `-e` specifies an input file which contains evm bytecode
  * `-o` specifies an output file which will contain the resulting wasm bytecode.

If an input file is not specified, then assume that the evm bytecode is a non-named argument.  This is the same behavior that is in place now.

I will document these when/if the PR is approved.