### PR TITLE
Make CLI expect the EVM bytecode source file to be ASCII encoded as UTF8

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ There is a commandline tool to transcompile EVM input:
 $ bin/evm2wasm.js -e `evm_bytecode_file` -o `wasm_output_file`
 ```
 
+`evm_bytecode_file` is expected to be UTF8 encoded ASCII
+
 #### Transcompile EVM to WAST
 ```
 $ bin/evm2wasm.js -e `evm_bytecode_file` -o `wasm_output_file` --wast

--- a/bin/evm2wasm.js
+++ b/bin/evm2wasm.js
@@ -63,9 +63,9 @@ try {
     }
   } else {
     bytecode = fs.readFileSync(file, 'utf8')
-    bytes = []
+    let bytes = []
     for (let i = 0; i < bytecode.length; i += 2) {
-      bytes.push(parseInt(bytecode.slice(i, i+2), '16'))
+      bytes.push(parseInt(bytecode.slice(i, i + 2), '16'))
     }
     bytecode = Buffer.from(bytes)
   }

--- a/bin/evm2wasm.js
+++ b/bin/evm2wasm.js
@@ -62,7 +62,12 @@ try {
       throw new Error('must provide evm bytecode file or supply bytecode as a non-named argument')
     }
   } else {
-    bytecode = fs.readFileSync(file).toString()
+    bytecode = fs.readFileSync(file, 'utf8')
+    bytes = []
+    for (let i = 0; i < bytecode.length; i += 2) {
+      bytes.push(parseInt(bytecode.slice(i, i+2), '16'))
+    }
+    bytecode = Buffer.from(bytes)
   }
 
   // always consider input EVM as a hex string and translate that into binary for the next stage


### PR DESCRIPTION
This makes interaction with Hera easier.