### PR TITLE
Add an option to charge gas per EVM opcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ $ bin/evm2wasm.js -e `evm_bytecode_file` -o `wasm_output_file` --wast
 $ bin/evm2wasm.js -e `evm_bytecode_file` -o `wasm_output_file` --wast --trace
 ```
 
+#### Transcompile EVM to WAST with gas metering per transpiled EVM opcode (not per branch segment)
+```
+$ bin/evm2wasm.js -e `evm_bytecode_file` -o `wasm_output_file` --wast --charge-per-op
+```
+
 # DEVELOP
 * After any changes to `.wast` file, `npm  run build` needs to be run to compile the files into a .json file 
 * To rebuild the documentation run `npm run build:docs`

--- a/bin/evm2wasm.js
+++ b/bin/evm2wasm.js
@@ -16,7 +16,8 @@ function convert (bytecode, opts) {
         stackTrace: opts.trace,
         tempName: 'temp',
         inlineOps: true,
-        wabt: false
+        wabt: false,
+        chargePerOp: false
       })
       resolve(output)
     } else {
@@ -24,7 +25,8 @@ function convert (bytecode, opts) {
         stackTrace: opts.trace,
         tempName: 'temp',
         inlineOps: true,
-        wabt: false
+        wabt: false,
+        chargePerOp: false
       }).then(function (output) {
         resolve(output)
       }).catch(function (err) {

--- a/bin/evm2wasm.js
+++ b/bin/evm2wasm.js
@@ -17,7 +17,7 @@ function convert (bytecode, opts) {
         tempName: 'temp',
         inlineOps: true,
         wabt: false,
-        chargePerOp: false
+        chargePerOp: opts.chargePerOp
       })
       resolve(output)
     } else {
@@ -26,7 +26,7 @@ function convert (bytecode, opts) {
         tempName: 'temp',
         inlineOps: true,
         wabt: false,
-        chargePerOp: false
+        chargePerOp: opts.chargePerOp
       }).then(function (output) {
         resolve(output)
       }).catch(function (err) {
@@ -52,6 +52,7 @@ const outputFile = argv.o ? argv.o : undefined
 const wast = argv.wast !== undefined
 const trace = argv.trace !== undefined
 const inputFile = argv.e ? argv.e : undefined
+const chargePerOp = argv['charge-per-op'] ? argv['charge-per-op'] : undefined
 
 let bytecode
 
@@ -70,7 +71,7 @@ try {
   // always consider input EVM as a hex string and translate that into binary for the next stage
   bytecode = Buffer.from(bytecode, 'hex')
 
-  convert(bytecode, { wast: wast, trace: trace }).then((result) => {
+  convert(bytecode, { wast: wast, trace: trace, chargePerOp: chargePerOp }).then((result) => {
     storeOrPrintResult(result, outputFile)
   }).catch((err) => {
     throw err

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,11 +14,12 @@ compiles evmCode to wasm in the binary format
 **Parameters**
 
 -   `evmCode` **[Array][5]** 
--   `opts` **[Object][6]**  (optional, default `{'stackTrace':false,'useAsyncAPI':false,'inlineOps':true,'testName':'temp'}`)
+-   `opts` **[Object][6]**  (optional, default `{'stackTrace':false,'useAsyncAPI':false,'inlineOps':true,'testName':'temp','chargePerOp':false}`)
     -   `opts.stackTrace` **[boolean][7]** if `true` generates an runtime EVM stack trace (default: false)
     -   `opts.inlineOps` **[boolean][7]** if `true` inlines the EVM1 operations (default: true)
     -   `opts.wabt` **[boolean][7]** use wabt to compile wast to wasm instad of the built in JS module (default: false)
     -   `opts.testName` **[String][8]** is the name used for the wast file (default: 'temp')
+    -   `opts.chargePerOp` **[boolean][7]** if `true` adds metering statements for the wasm code section corresponding to each EVM opcode as opposed to metering once per branch segment (default: false).
 
 Returns **[string][8]** 
 
@@ -41,9 +42,10 @@ All segments start at
 **Parameters**
 
 -   `evmCode` **Integer** the evm byte code
--   `opts` **[Object][6]**  (optional, default `{'stackTrace':false,'useAsyncAPI':false,'inlineOps':true}`)
+-   `opts` **[Object][6]**  (optional, default `{'stackTrace':false,'useAsyncAPI':false,'inlineOps':true,'chargePerOp':false}`)
     -   `opts.stackTrace` **[boolean][7]** if `true` generates a stack trace (default: false)
     -   `opts.inlineOps` **[boolean][7]** if `true` inlines the EVM1 operations (default: true)
+    -   `opts.chargePerOp` **[boolean][7]** if `true` adds metering statements for the wasm code section corresponding to each EVM opcode as opposed to metering once per branch segment (default: false).
 
 Returns **[string][8]** 
 


### PR DESCRIPTION
Adds a new optional feature that modifies gas metering:
 * Adds calls to `useGas` at the beginning of each piece of produced wasm/wast corresponding to an EVM opcode.

This is important for producing Hera trace output that aligns with existing Ethereum clients.

Fixes #197. Depends on #207 and #211.