### PR TITLE
Fix trace format to print op fee

### DIFF
--- a/index.js
+++ b/index.js
@@ -182,7 +182,7 @@ exports.evm2wast = function (evmCode, opts = {
 
     // creates a stack trace
     if (opts.stackTrace) {
-      segment += `(call $stackTrace (i32.const ${pc}) (i32.const ${opint}) (i32.const ${gasCount}) (get_global $sp))\n`
+      segment += `(call $stackTrace (i32.const ${pc}) (i32.const ${opint}) (i32.const ${op.fee}) (get_global $sp))\n`
     }
 
     let bytes


### PR DESCRIPTION
rather than printing cumulative gas consumed

CC @axic, as discussed a couple of days ago.