### PR TITLE
Don't silently swallow async errors

### DIFF
--- a/bin/evm2wasm.js
+++ b/bin/evm2wasm.js
@@ -76,7 +76,9 @@ try {
   convert(bytecode, { wast: wast, trace: trace, chargePerOp: chargePerOp }).then((result) => {
     storeOrPrintResult(result, outputFile)
   }).catch((err) => {
-    throw err
+    // Separately handle async promise errors here so they're not swallowed silently
+    console.error('Error:' + err)
+    process.exit(1)
   })
 } catch (err) {
   console.error('Error: ' + err)


### PR DESCRIPTION
Errors that occur during bytecode conversion were being silently swalled inside a promise